### PR TITLE
conf/layer: rename trustx-{intel|layer} to gyroidos-{intel|layer}

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
 	agent any
 
 	parameters {
-		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
+		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-gyroidos=PR-177,meta-gyroidos-nxp=PR-13,gyroidos_build=PR-97)')
 	}
 
 	stages {

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,10 +5,10 @@ BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
 	   ${LAYERDIR}/images/*.bb*"
 
 
-BBFILE_COLLECTIONS += "trustx-intel"
-BBFILE_PATTERN_trustx-intel := "^${LAYERDIR}/"
-BBFILE_PRIORITY_trustx-intel := "7"
+BBFILE_COLLECTIONS += "gyroidos-intel"
+BBFILE_PATTERN_gyroidos-intel := "^${LAYERDIR}/"
+BBFILE_PRIORITY_gyroidos-intel := "7"
 
-LAYERDEPENDS_trustx-intel = "trustx-layer"
+LAYERDEPENDS_gyroidos-intel = "gyroidos-layer"
 
-LAYERSERIES_COMPAT_trustx-intel += "kirkstone"
+LAYERSERIES_COMPAT_gyroidos-intel += "kirkstone"


### PR DESCRIPTION
In layer.conf, we also change the name from the former codename-based trustx-layer and trustx-intel to gyroidos-layer and gyroidos-intel.