### PR TITLE
conf/multiconfig/installer: remove debug-tweaks from IMAGE_FEATURES

### DIFF
--- a/conf/multiconfig/installer.conf
+++ b/conf/multiconfig/installer.conf
@@ -1,4 +1,3 @@
-EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 USER_CLASSES ?= "buildstats"
 PATCHRESOLVE = "noop"
 


### PR DESCRIPTION
Since Scarthgap, debug-tweaks installs to many debugging stuff which exceeds images size of 3500K. Thus just remove them from installer image, since the installer is never build with DEVELOPMENTBUILD flag enable, which would set INITRAMFS_MAXSIZE accordingly higher.

Fixes following build error:

  ERROR: mc:installer:gyroidos-installer-initramfs-1.0-r0 do_image_cpio: \
  The initramfs size 79810(K) exceeds INITRAMFS_MAXSIZE: 35000(K)