### PR TITLE
efitools-common: Update fix for strptime includes

### DIFF
--- a/recipes-kernel/efitools/efitools-common.inc
+++ b/recipes-kernel/efitools/efitools-common.inc
@@ -8,5 +8,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e28f66b16cb46be47b20a4cdfe6e99a1"
 
 SRC_URI = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/snapshot/efitools_${PV}.tar.gz"
 SRC_URI += "file://0001-lib-console-compatibly-fix-to-upstream-change-of-gnu.patch"
+SRC_URI += "0001-flash-var-sign-efi-sig-list-Fix-include-for-strptime.patch"
 
 S = "${WORKDIR}/efitools_${PV}"

--- a/recipes-kernel/efitools/efitools/0001-Fix-includes-for-strptime.patch
+++ b/recipes-kernel/efitools/efitools/0001-Fix-includes-for-strptime.patch
@@ -1,0 +1,38 @@
+From 9cf5ad3f1926c32860e5209c51737e567f446212 Mon Sep 17 00:00:00 2001
+From: Felix Wruck <felix.wruck@aisec.fraunhofer.de>
+Date: Fri, 19 Sep 2025 10:49:49 +0200
+Subject: [PATCH] Fix includes for strptime
+
+---
+ flash-var.c         | 3 +++
+ sign-efi-sig-list.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/flash-var.c b/flash-var.c
+index aa10ae6..007ff68 100644
+--- a/flash-var.c
++++ b/flash-var.c
+@@ -1,3 +1,6 @@
++#define _XOPEN_SOURCE
++#include <time.h>
++
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <sys/types.h>
+diff --git a/sign-efi-sig-list.c b/sign-efi-sig-list.c
+index 94bd7d4..7a4c91b 100644
+--- a/sign-efi-sig-list.c
++++ b/sign-efi-sig-list.c
+@@ -3,6 +3,9 @@
+  *
+  * see COPYING file
+  */
++#define _XOPEN_SOURCE
++#include <time.h>
++
+ #include <stdint.h>
+ #define __STDC_VERSION__ 199901L
+ #include <efi.h>
+-- 
+2.47.3
+

--- a/recipes-kernel/efitools/efitools/0001-flash-var-sign-efi-sig-list-Fix-include-for-strptime.patch
+++ b/recipes-kernel/efitools/efitools/0001-flash-var-sign-efi-sig-list-Fix-include-for-strptime.patch
@@ -1,0 +1,44 @@
+From cfba1434e3aea571b9be9e2315a8df66d0c8f5a4 Mon Sep 17 00:00:00 2001
+From: Felix Wruck <felix.wruck@aisec.fraunhofer.de>
+Date: Fri, 19 Sep 2025 10:49:49 +0200
+Subject: [PATCH] flash-var, sign-efi-sig-list: Fix include for strptime
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently, builds with strict GCC flags fail due to an
+"error: implicit declaration of function ‘strptime’".
+
+Therefore, add the missing #define _XOPEN_SOURCE in flash-var.c
+and sign-efi-sig-list.c before including time.h.
+
+Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>
+---
+ flash-var.c         | 1 +
+ sign-efi-sig-list.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/flash-var.c b/flash-var.c
+index aa10ae6..d5f5f2f 100644
+--- a/flash-var.c
++++ b/flash-var.c
+@@ -1,3 +1,4 @@
++#define _XOPEN_SOURCE
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <sys/types.h>
+diff --git a/sign-efi-sig-list.c b/sign-efi-sig-list.c
+index 94bd7d4..c096c70 100644
+--- a/sign-efi-sig-list.c
++++ b/sign-efi-sig-list.c
+@@ -3,6 +3,7 @@
+  *
+  * see COPYING file
+  */
++#define _XOPEN_SOURCE
+ #include <stdint.h>
+ #define __STDC_VERSION__ 199901L
+ #include <efi.h>
+-- 
+2.47.3
+


### PR DESCRIPTION
Update fix related to build errors with Debian Trixie due to compiler warnings related to a missing definition of _XOPEN_SOURCE in sign-efi-sig-list.c and flash-var.c.